### PR TITLE
Updated the functionality of several summoner spells, and added some …

### DIFF
--- a/Buffs/BotrkBuff/BotrkBuff.cs
+++ b/Buffs/BotrkBuff/BotrkBuff.cs
@@ -1,0 +1,48 @@
+﻿using LeagueSandbox.GameServer.Logic.API;
+using LeagueSandbox.GameServer.Logic.GameObjects;
+using LeagueSandbox.GameServer.Logic.GameObjects.AttackableUnits;
+using LeagueSandbox.GameServer.Logic.Scripting;
+
+namespace BotrkBuff
+{
+    internal class BotrkBuff : BuffGameScript
+    {
+        private ChampionStatModifier _statMod;
+        private ObjAIBase _owningUnit;
+
+        public void OnActivate(ObjAIBase unit, Spell ownerSpell)
+        {
+            _owningUnit = unit;
+            _statMod = new ChampionStatModifier();
+            _statMod.LifeSteel.FlatBonus = 0.1f;
+            unit.AddStatModifier(_statMod);
+            ApiEventManager.OnAutoAttackHit.AddListener(this, unit, OnHitEffect);
+        }
+
+        public void OnDeactivate(ObjAIBase unit)
+        {
+            ApiEventManager.OnAutoAttackHit.RemoveListener(this);
+            unit.RemoveStatModifier(_statMod);
+        }
+
+        private void OnHitEffect(AttackableUnit target, bool isCrit)
+        {
+            if (!(target is ObjAIBase)) // Blade of the Ruined King will only damage minions, monsters, and champions.
+            {
+                return;
+            }
+
+            var damage = System.Math.Max(target.GetStats().CurrentHealth * 0.08f, 15); // 8% of the target's current health (15 minimum)
+            if (target is Minion || target is Monster) // Bonus Damage from Blade of the Ruined King is capped at 60 for Minions and Monsters.
+            {
+                damage = System.Math.Min(damage, 60);
+            }
+            target.TakeDamage(_owningUnit, damage, DamageType.DAMAGE_TYPE_PHYSICAL, DamageSource.DAMAGE_SOURCE_PASSIVE, false);
+        }
+
+        public void OnUpdate(double diff)
+        {
+
+        }
+    }
+}

--- a/Buffs/ShurelyasReverie/ShurelyasReverie.cs
+++ b/Buffs/ShurelyasReverie/ShurelyasReverie.cs
@@ -1,0 +1,27 @@
+﻿using LeagueSandbox.GameServer.Logic.GameObjects;
+using LeagueSandbox.GameServer.Logic.Scripting;
+
+namespace ShurelyasReverie
+{
+    internal class ShurelyasReverie : BuffGameScript
+    {
+        private ChampionStatModifier _statMod;
+
+        public void OnActivate(ObjAIBase unit, Spell ownerSpell)
+        {
+            _statMod = new ChampionStatModifier();
+            _statMod.MoveSpeed.PercentBonus = 0.4f;
+            unit.AddStatModifier(_statMod);
+        }
+
+        public void OnDeactivate(ObjAIBase unit)
+        {
+            unit.RemoveStatModifier(_statMod);
+        }
+
+        public void OnUpdate(double diff)
+        {
+
+        }
+    }
+}

--- a/Buffs/YoumusBlade/YoumusBlade.cs
+++ b/Buffs/YoumusBlade/YoumusBlade.cs
@@ -1,0 +1,28 @@
+﻿using LeagueSandbox.GameServer.Logic.GameObjects;
+using LeagueSandbox.GameServer.Logic.Scripting;
+
+namespace YoumusBlade
+{
+    internal class YoumusBlade : BuffGameScript
+    {
+        private ChampionStatModifier _statMod;
+
+        public void OnActivate(ObjAIBase unit, Spell ownerSpell)
+        {
+            _statMod = new ChampionStatModifier();
+            _statMod.AttackSpeed.PercentBonus = 0.4f;
+            _statMod.MoveSpeed.PercentBonus = 0.2f;
+            unit.AddStatModifier(_statMod);
+        }
+
+        public void OnDeactivate(ObjAIBase unit)
+        {
+            unit.RemoveStatModifier(_statMod);
+        }
+
+        public void OnUpdate(double diff)
+        {
+
+        }
+    }
+}

--- a/Champions/Global/FlaskOfCrystalWater.cs
+++ b/Champions/Global/FlaskOfCrystalWater.cs
@@ -1,0 +1,55 @@
+﻿using LeagueSandbox.GameServer.Logic.GameObjects;
+using LeagueSandbox.GameServer.Logic.API;
+using LeagueSandbox.GameServer.Logic.Scripting.CSharp;
+using LeagueSandbox.GameServer.Logic.GameObjects.AttackableUnits;
+
+namespace Spells
+{
+    public class FlaskOfCrystalWater : GameScript
+    {
+        public void OnStartCasting(Champion owner, Spell spell, AttackableUnit target)
+        {
+        }
+
+        public void OnFinishCasting(Champion owner, Spell spell, AttackableUnit target)
+        {
+            for (int i = 0; i < 30; i++)
+            {
+                ApiFunctionManager.CreateTimer(i * 0.5f, () =>
+                   {
+                       var maxMana = owner.GetStats().ManaPoints.Total;
+                       var newMana = owner.GetStats().CurrentMana + 3.33f;
+                       if (newMana > maxMana)
+                       {
+                           owner.GetStats().CurrentMana = maxMana;
+                       }
+                       else
+                       {
+                           owner.GetStats().CurrentMana = newMana;
+                       }
+                   });
+            }
+            var p = ApiFunctionManager.AddParticleTarget(owner, "GLOBAL_Item_ManaPotion.troy", owner);
+            ApiFunctionManager.CreateTimer(15f, () =>
+             {
+                 ApiFunctionManager.RemoveParticle(p);
+             });
+        }
+
+        public void ApplyEffects(Champion owner, AttackableUnit target, Spell spell, Projectile projectile)
+        {
+        }
+
+        public void OnUpdate(double diff)
+        {
+        }
+
+        public void OnActivate(Champion owner)
+        {
+        }
+
+        public void OnDeactivate(Champion owner)
+        {
+        }
+    }
+}

--- a/Champions/Global/ItemSmiteAoE.cs
+++ b/Champions/Global/ItemSmiteAoE.cs
@@ -1,0 +1,91 @@
+﻿using LeagueSandbox.GameServer.Logic.GameObjects;
+using LeagueSandbox.GameServer.Logic.API;
+using LeagueSandbox.GameServer.Logic.Scripting.CSharp;
+using LeagueSandbox.GameServer.Logic.GameObjects.AttackableUnits;
+
+namespace Spells
+{
+    public class ItemSmiteAoE : GameScript
+    {
+        public void OnStartCasting(Champion owner, Spell spell, AttackableUnit target)
+        {
+            ApiFunctionManager.AddParticleTarget(owner, "Global_SS_Smite_AoEStun_Monster.troy", target, 1);
+            var damage = (new float[] { 390, 410, 430, 450, 480, 510, 540, 570, 600, 640, 680, 720, 760, 800, 850, 900, 950, 1000 })[owner.GetStats().Level - 1];
+            target.TakeDamage(owner, damage, DamageType.DAMAGE_TYPE_TRUE, DamageSource.DAMAGE_SOURCE_SUMMONER_SPELL, false);
+            var AOEDamage = damage / 2;
+            var buff1 = ((ObjAIBase)target).AddBuffGameScript("Stun", "Stun", spell);
+            ApiFunctionManager.CreateTimer(1.5f, () =>
+            {
+                ((ObjAIBase)target).RemoveBuffGameScript(buff1);
+            });
+            var spellData = spell.SpellData;
+            var sideTargets = ApiFunctionManager.GetUnitsInRange(target, spellData.BounceRadius, true);
+            foreach (AttackableUnit additionalTarget in sideTargets)
+            {
+                if((additionalTarget is Minion) || (additionalTarget is Monster))
+                {
+                    if(additionalTarget.Team == owner.Team)
+                    {
+                        continue;
+                    }
+                    additionalTarget.TakeDamage(owner,AOEDamage,DamageType.DAMAGE_TYPE_TRUE, DamageSource.DAMAGE_SOURCE_SUMMONER_SPELL,false);
+                    if (!additionalTarget.IsDead)
+                    {
+                        var buff2 = ((ObjAIBase)additionalTarget).AddBuffGameScript("Stun", "Stun", spell);
+                        ApiFunctionManager.CreateTimer(1.5f, () =>
+                         {
+                             ((ObjAIBase)additionalTarget).RemoveBuffGameScript(buff2);
+                         });
+                    }
+                }
+            }
+
+            if (target is Monster) {
+                RestoreHealth(owner);
+                RestoreMana(owner);
+            }
+        }
+
+        public void RestoreHealth(Champion owner)
+        {
+            var maxHealth = owner.GetStats().HealthPoints.Total;
+            var missingHealth = (maxHealth) - (owner.GetStats().CurrentHealth);
+            owner.RestoreHealth(missingHealth);
+        }
+
+        public void RestoreMana(Champion owner)
+        {
+            var maxMana = owner.GetStats().ManaPoints.Total;
+            var missingMana = maxMana - (owner.GetStats().CurrentMana);
+            var newMana = (owner.GetStats().CurrentMana) + (missingMana * 0.15f);
+            if (newMana >= maxMana)
+            {
+                owner.GetStats().CurrentMana = maxMana;
+            }
+            else
+            {
+                owner.GetStats().CurrentMana = newMana;
+            }
+        }
+
+        public void OnFinishCasting(Champion owner, Spell spell, AttackableUnit target)
+        {
+        }
+
+        public void ApplyEffects(Champion owner, AttackableUnit target, Spell spell, Projectile projectile)
+        {
+        }
+
+        public void OnUpdate(double diff)
+        {
+        }
+
+        public void OnActivate(Champion owner)
+        {
+        }
+
+        public void OnDeactivate(Champion owner)
+        {
+        }
+    }
+}

--- a/Champions/Global/ItemSwordOfFeastAndFamine.cs
+++ b/Champions/Global/ItemSwordOfFeastAndFamine.cs
@@ -1,17 +1,18 @@
-using LeagueSandbox.GameServer.Logic.GameObjects;
+﻿using LeagueSandbox.GameServer.Logic.GameObjects;
 using LeagueSandbox.GameServer.Logic.API;
 using LeagueSandbox.GameServer.Logic.Scripting.CSharp;
 using LeagueSandbox.GameServer.Logic.GameObjects.AttackableUnits;
 
 namespace Spells
 {
-    public class SummonerSmite : GameScript
+    public class ItemSwordOfFeastAndFamine : GameScript
     {
+
+        private Champion _owningChampion;
+        private BuffGameScriptController _botrkBuff;
+
         public void OnStartCasting(Champion owner, Spell spell, AttackableUnit target)
         {
-            ApiFunctionManager.AddParticleTarget(owner, "Global_SS_Smite.troy", target, 1);
-            var damage = (new float[] { 390, 410, 430, 450, 480, 510, 540, 570, 600, 640, 680, 720, 760, 800, 850, 900, 950, 1000}) [owner.GetStats().Level - 1];
-            target.TakeDamage(owner, damage, DamageType.DAMAGE_TYPE_TRUE, DamageSource.DAMAGE_SOURCE_SUMMONER_SPELL, false);
         }
 
         public void OnFinishCasting(Champion owner, Spell spell, AttackableUnit target)
@@ -28,11 +29,13 @@ namespace Spells
 
         public void OnActivate(Champion owner)
         {
+            _owningChampion = owner;
+            _botrkBuff = owner.AddBuffGameScript("BotrkBuff", "BotrkBuff", null);
         }
 
         public void OnDeactivate(Champion owner)
         {
+            owner.RemoveBuffGameScript(_botrkBuff);
         }
     }
 }
-

--- a/Champions/Global/ItemTiamatCleave.cs
+++ b/Champions/Global/ItemTiamatCleave.cs
@@ -1,0 +1,94 @@
+﻿using LeagueSandbox.GameServer.Logic.GameObjects;
+using LeagueSandbox.GameServer.Logic.API;
+using LeagueSandbox.GameServer.Logic.Scripting.CSharp;
+using LeagueSandbox.GameServer.Logic.GameObjects.AttackableUnits;
+using System.Collections.Generic;
+
+namespace Spells
+{
+    public class ItemTiamatCleave : GameScript
+    {
+
+        private Champion _owningChampion;
+
+        public void OnStartCasting(Champion owner, Spell spell, AttackableUnit target)
+        {
+        }
+
+        public void OnFinishCasting(Champion owner, Spell spell, AttackableUnit target)
+        {
+            ApiFunctionManager.AddParticleTarget(_owningChampion, "TiamatMelee_itm_active.troy", target);
+            var closeRangeTargets = ApiFunctionManager.GetUnitsInRange(owner, 200, true);
+            var midRangeTargets = ApiFunctionManager.GetUnitsInRange(owner, 300, true);
+            var farRangeTargets = ApiFunctionManager.GetUnitsInRange(owner, 400, true);
+            CorrectLists(closeRangeTargets, midRangeTargets, farRangeTargets);
+
+            var ad = _owningChampion.GetStats().AttackDamage.Total;
+            foreach (var unit in closeRangeTargets)
+            {
+                unit.TakeDamage(_owningChampion, ad * 0.6f, DamageType.DAMAGE_TYPE_PHYSICAL, DamageSource.DAMAGE_SOURCE_PASSIVE, false);
+            }
+            foreach (var unit in midRangeTargets)
+            {
+                unit.TakeDamage(_owningChampion, ad * 0.4f, DamageType.DAMAGE_TYPE_PHYSICAL, DamageSource.DAMAGE_SOURCE_PASSIVE, false);
+            }
+            foreach (var unit in farRangeTargets)
+            {
+                unit.TakeDamage(_owningChampion, ad * 0.2f, DamageType.DAMAGE_TYPE_PHYSICAL, DamageSource.DAMAGE_SOURCE_PASSIVE, false);
+            }
+        }
+
+        public void ApplyEffects(Champion owner, AttackableUnit target, Spell spell, Projectile projectile)
+        {
+        }
+
+        public void OnUpdate(double diff)
+        {
+        }
+
+        public void OnActivate(Champion owner)
+        {
+            _owningChampion = owner;
+            ApiEventManager.OnAutoAttackHit.AddListener(this, owner, ApplyCleave);
+        }
+
+        private void ApplyCleave(AttackableUnit target, bool isCrit)
+        {
+            ApiFunctionManager.AddParticleTarget(_owningChampion, "TiamatMelee_itm.troy", target);
+            var closeRangeTargets = ApiFunctionManager.GetUnitsInRange(target, 185, true);
+            var midRangeTargets = ApiFunctionManager.GetUnitsInRange(target, 285, true);
+            var farRangeTargets = ApiFunctionManager.GetUnitsInRange(target, 385, true);
+            CorrectLists(closeRangeTargets, midRangeTargets, farRangeTargets);
+
+            var ad = _owningChampion.GetStats().AttackDamage.Total;
+            foreach(var unit in closeRangeTargets)
+            {
+                unit.TakeDamage(_owningChampion, ad * 0.6f, DamageType.DAMAGE_TYPE_PHYSICAL, DamageSource.DAMAGE_SOURCE_PASSIVE, false);
+            }
+            foreach(var unit in midRangeTargets)
+            {
+                unit.TakeDamage(_owningChampion, ad * 0.4f, DamageType.DAMAGE_TYPE_PHYSICAL, DamageSource.DAMAGE_SOURCE_PASSIVE, false);
+            }
+            foreach(var unit in farRangeTargets)
+            {
+                unit.TakeDamage(_owningChampion, ad * 0.2f, DamageType.DAMAGE_TYPE_PHYSICAL, DamageSource.DAMAGE_SOURCE_PASSIVE, false);
+            }
+        }
+
+        // Remove units that overlap between the three tiamat ranges, and clear out allied units.
+        private void CorrectLists(List<AttackableUnit> closeRange, List<AttackableUnit> midRange, List<AttackableUnit> farRange)
+        {
+            farRange.RemoveAll((unit) => (midRange.Contains(unit)));
+            midRange.RemoveAll((unit) => (closeRange.Contains(unit)));
+            closeRange.RemoveAll((unit) => (unit.Team == _owningChampion.Team));
+            midRange.RemoveAll((unit) => (unit.Team == _owningChampion.Team));
+            farRange.RemoveAll((unit) => (unit.Team == _owningChampion.Team));
+        }
+
+        public void OnDeactivate(Champion owner)
+        {
+            ApiEventManager.OnAutoAttackHit.RemoveListener(this);
+        }
+    }
+}
+

--- a/Champions/Global/RegenerationPotion.cs
+++ b/Champions/Global/RegenerationPotion.cs
@@ -1,21 +1,30 @@
-using LeagueSandbox.GameServer.Logic.GameObjects;
+﻿using LeagueSandbox.GameServer.Logic.GameObjects;
 using LeagueSandbox.GameServer.Logic.API;
 using LeagueSandbox.GameServer.Logic.Scripting.CSharp;
 using LeagueSandbox.GameServer.Logic.GameObjects.AttackableUnits;
 
 namespace Spells
 {
-    public class SummonerSmite : GameScript
+    public class RegenerationPotion : GameScript
     {
         public void OnStartCasting(Champion owner, Spell spell, AttackableUnit target)
         {
-            ApiFunctionManager.AddParticleTarget(owner, "Global_SS_Smite.troy", target, 1);
-            var damage = (new float[] { 390, 410, 430, 450, 480, 510, 540, 570, 600, 640, 680, 720, 760, 800, 850, 900, 950, 1000}) [owner.GetStats().Level - 1];
-            target.TakeDamage(owner, damage, DamageType.DAMAGE_TYPE_TRUE, DamageSource.DAMAGE_SOURCE_SUMMONER_SPELL, false);
         }
 
         public void OnFinishCasting(Champion owner, Spell spell, AttackableUnit target)
         {
+            for (int i = 0; i < 30; i++)
+            {
+                ApiFunctionManager.CreateTimer(i * 0.5f, () =>
+                {
+                    owner.RestoreHealth(5.0f); // This will cause Health Potions to have half effect on champions effected by Grievous Wounds.
+                });
+            }
+            var p = ApiFunctionManager.AddParticleTarget(owner, "GLOBAL_Item_HealthPotion.troy", owner);
+            ApiFunctionManager.CreateTimer(15f, () =>
+            {
+                ApiFunctionManager.RemoveParticle(p);
+            });
         }
 
         public void ApplyEffects(Champion owner, AttackableUnit target, Spell spell, Projectile projectile)
@@ -35,4 +44,3 @@ namespace Spells
         }
     }
 }
-

--- a/Champions/Global/SummonerDot.cs
+++ b/Champions/Global/SummonerDot.cs
@@ -11,29 +11,30 @@ namespace Spells
         {
             var visualBuff = ApiFunctionManager.AddBuffHUDVisual("SummonerDot", 5.0f, 1, (ObjAIBase) target);
             Particle p = ApiFunctionManager.AddParticleTarget(owner, "Global_SS_Ignite.troy", target, 1);
+            ((ObjAIBase)target).AddBuffGameScript("GrievousWounds", "GrievousWounds", spell, 4.0f);
             var damage = 10 + owner.GetStats().Level * 4;
-            target.TakeDamage(owner, damage, DamageType.DAMAGE_TYPE_TRUE, DamageSource.DAMAGE_SOURCE_SPELL, false);
+            target.TakeDamage(owner, damage, DamageType.DAMAGE_TYPE_TRUE, DamageSource.DAMAGE_SOURCE_SUMMONER_SPELL, false);
             ApiFunctionManager.CreateTimer(1.0f,
                 () =>
                 {
-                    target.TakeDamage(owner, damage, DamageType.DAMAGE_TYPE_TRUE, DamageSource.DAMAGE_SOURCE_SPELL,
+                    target.TakeDamage(owner, damage, DamageType.DAMAGE_TYPE_TRUE, DamageSource.DAMAGE_SOURCE_SUMMONER_SPELL,
                         false);
                 });
             ApiFunctionManager.CreateTimer(2.0f,
                 () =>
                 {
-                    target.TakeDamage(owner, damage, DamageType.DAMAGE_TYPE_TRUE, DamageSource.DAMAGE_SOURCE_SPELL,
+                    target.TakeDamage(owner, damage, DamageType.DAMAGE_TYPE_TRUE, DamageSource.DAMAGE_SOURCE_SUMMONER_SPELL,
                         false);
                 });
             ApiFunctionManager.CreateTimer(3.0f,
                 () =>
                 {
-                    target.TakeDamage(owner, damage, DamageType.DAMAGE_TYPE_TRUE, DamageSource.DAMAGE_SOURCE_SPELL,
+                    target.TakeDamage(owner, damage, DamageType.DAMAGE_TYPE_TRUE, DamageSource.DAMAGE_SOURCE_SUMMONER_SPELL,
                         false);
                 });
             ApiFunctionManager.CreateTimer(4.0f, () =>
             {
-                target.TakeDamage(owner, damage, DamageType.DAMAGE_TYPE_TRUE, DamageSource.DAMAGE_SOURCE_SPELL, false);
+                target.TakeDamage(owner, damage, DamageType.DAMAGE_TYPE_TRUE, DamageSource.DAMAGE_SOURCE_SUMMONER_SPELL, false);
                 ApiFunctionManager.RemoveParticle(p);
                 ApiFunctionManager.RemoveBuffHUDVisual(visualBuff);
             });

--- a/Champions/Global/SummonerExhaust.cs
+++ b/Champions/Global/SummonerExhaust.cs
@@ -13,18 +13,23 @@ namespace Spells
 
         public void OnFinishCasting(Champion owner, Spell spell, AttackableUnit target)
         {
+            ObjAIBase aiTarget = target as ObjAIBase;
+            if(aiTarget == null)
+            {
+                return;
+            }
             ChampionStatModifier statMod = new ChampionStatModifier();
             statMod.MoveSpeed.PercentBonus -= 30.0f / 100.0f;
             statMod.AttackSpeed.PercentBonus -= 30.0f / 100.0f;
             statMod.Armor.BaseBonus -= 10;
             statMod.MagicResist.BaseBonus -= 10;
-            target.AddStatModifier(statMod);
+            aiTarget.AddStatModifier(statMod);
             ApiFunctionManager.AddParticleTarget(owner, "Global_SS_Exhaust.troy", target);
             var visualBuff = ApiFunctionManager.AddBuffHUDVisual("SummonerExhaustDebuff", 2.5f, 1, (ObjAIBase) target);
             ApiFunctionManager.CreateTimer(2.5f, () =>
             {
                 ApiFunctionManager.RemoveBuffHUDVisual(visualBuff);
-                target.RemoveStatModifier(statMod);
+                aiTarget.RemoveStatModifier(statMod);
             });
         }
 

--- a/Champions/Global/SummonerHeal.cs
+++ b/Champions/Global/SummonerHeal.cs
@@ -35,16 +35,8 @@ namespace Spells
 
             if (mostWoundedAlliedChampion != null)
             {
-                newHealth = mostWoundedAlliedChampion.GetStats().CurrentHealth + 75 + owner.GetStats().GetLevel() * 15;
-                maxHealth = mostWoundedAlliedChampion.GetStats().HealthPoints.Total;
-                if (newHealth >= maxHealth)
-                {
-                    mostWoundedAlliedChampion.GetStats().CurrentHealth = maxHealth;
-                }
-                else
-                {
-                    mostWoundedAlliedChampion.GetStats().CurrentHealth = newHealth;
-                }
+                newHealth = 75 + owner.GetStats().GetLevel() * 15;
+                mostWoundedAlliedChampion.RestoreHealth(newHealth);
 
                 ApiFunctionManager.AddBuffHUDVisual("SummonerHeal", 1.0f, 1, mostWoundedAlliedChampion, 1.0f);
                 ChampionStatModifier statMod2 = new ChampionStatModifier();
@@ -57,16 +49,8 @@ namespace Spells
                     mostWoundedAlliedChampion);
             }
 
-            newHealth = owner.GetStats().CurrentHealth + 75 + owner.GetStats().GetLevel() * 15;
-            maxHealth = owner.GetStats().HealthPoints.Total;
-            if (newHealth >= maxHealth)
-            {
-                owner.GetStats().CurrentHealth = maxHealth;
-            }
-            else
-            {
-                owner.GetStats().CurrentHealth = newHealth;
-            }
+            newHealth = 75 + owner.GetStats().GetLevel() * 15;
+            owner.RestoreHealth(newHealth);
 
             ApiFunctionManager.AddBuffHUDVisual("SummonerHeal", 1.0f, 1, owner, 1.0f);
             ChampionStatModifier statMod = new ChampionStatModifier();

--- a/Champions/Global/YoumusBlade.cs
+++ b/Champions/Global/YoumusBlade.cs
@@ -1,17 +1,20 @@
-using LeagueSandbox.GameServer.Logic.GameObjects;
+﻿using LeagueSandbox.GameServer.Logic.GameObjects;
 using LeagueSandbox.GameServer.Logic.API;
 using LeagueSandbox.GameServer.Logic.Scripting.CSharp;
 using LeagueSandbox.GameServer.Logic.GameObjects.AttackableUnits;
 
 namespace Spells
 {
-    public class SummonerSmite : GameScript
+    public class YoumusBlade : GameScript
     {
         public void OnStartCasting(Champion owner, Spell spell, AttackableUnit target)
         {
-            ApiFunctionManager.AddParticleTarget(owner, "Global_SS_Smite.troy", target, 1);
-            var damage = (new float[] { 390, 410, 430, 450, 480, 510, 540, 570, 600, 640, 680, 720, 760, 800, 850, 900, 950, 1000}) [owner.GetStats().Level - 1];
-            target.TakeDamage(owner, damage, DamageType.DAMAGE_TYPE_TRUE, DamageSource.DAMAGE_SOURCE_SUMMONER_SPELL, false);
+            var buff = ((ObjAIBase)target).AddBuffGameScript("YoumusBlade", "YoumusBlade", spell,6.0f);
+            var p = ApiFunctionManager.AddParticleTarget(owner, "spectral_fury_activate_speed.troy", owner, 2);
+            ApiFunctionManager.CreateTimer(6.0f, () =>
+             {
+                 ApiFunctionManager.RemoveParticle(p);
+             });
         }
 
         public void OnFinishCasting(Champion owner, Spell spell, AttackableUnit target)
@@ -35,4 +38,3 @@ namespace Spells
         }
     }
 }
-

--- a/Champions/Global/shurelyascrest.cs
+++ b/Champions/Global/shurelyascrest.cs
@@ -1,17 +1,24 @@
-using LeagueSandbox.GameServer.Logic.GameObjects;
+﻿using LeagueSandbox.GameServer.Logic.GameObjects;
 using LeagueSandbox.GameServer.Logic.API;
 using LeagueSandbox.GameServer.Logic.Scripting.CSharp;
 using LeagueSandbox.GameServer.Logic.GameObjects.AttackableUnits;
 
 namespace Spells
 {
-    public class SummonerSmite : GameScript
+    public class shurelyascrest : GameScript
     {
         public void OnStartCasting(Champion owner, Spell spell, AttackableUnit target)
         {
-            ApiFunctionManager.AddParticleTarget(owner, "Global_SS_Smite.troy", target, 1);
-            var damage = (new float[] { 390, 410, 430, 450, 480, 510, 540, 570, 600, 640, 680, 720, 760, 800, 850, 900, 950, 1000}) [owner.GetStats().Level - 1];
-            target.TakeDamage(owner, damage, DamageType.DAMAGE_TYPE_TRUE, DamageSource.DAMAGE_SOURCE_SUMMONER_SPELL, false);
+            var targets = ApiFunctionManager.GetUnitsInRange(owner, 600, true);
+            foreach(AttackableUnit unit in targets) {
+                if (unit is Champion || unit is Minion)
+                {
+                    if (unit.Team == owner.Team)
+                    {
+                        ((ObjAIBase)unit).AddBuffGameScript("ShurelyasReverie", "ShurelyasReverie", spell, 3.0f);
+                    }
+                }
+            }
         }
 
         public void OnFinishCasting(Champion owner, Spell spell, AttackableUnit target)
@@ -35,4 +42,3 @@ namespace Spells
         }
     }
 }
-


### PR DESCRIPTION
…item actives.

Ignite now properly applies Grievous Wounds, while Heal is now effected by it. Smite now uses the same level scaling League of Legends officially used in 4.20. Additionally, the items (and buffs accompanying them) Talisman of Ascension, Mana Potion, Health Potion, Youmuu's Ghostblade, Tiamat, Ravenous Hydra, and Talisman of Ascension (the final of which is referenced by its original name, Shurelya's Reverie) have their active componets implemented here. Finally, the passive effect of Blade of the Ruined King is implemented as well.